### PR TITLE
Ensure versioncmp 'a' parameter is a string

### DIFF
--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -58,7 +58,7 @@ define augeas::lens (
     mode => '0644',
   }
 
-  if (!$stock_since or versioncmp($::augeasversion, $stock_since) < 0) {
+  if (!$stock_since or versioncmp("${::augeasversion}", $stock_since) < 0) {
 
     assert_type(Pattern[/^\/.*/], $augeas::lens_dir)
 


### PR DESCRIPTION
Fixes:
> Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef (file: /etc/puppetlabs/code/environments/production/modules/augeas/manifests/lens.pp, line: 61, column: 24) (file: /etc/puppetlabs/code/environments/production/modules/postfix/manifests/augeas.pp, line: 7) on node [...]